### PR TITLE
Update Ingress api for eks upgrade

### DIFF
--- a/deployment/stacks/service/base/template/proxy/uec-dos-api-cs-proxy-ingress.yaml
+++ b/deployment/stacks/service/base/template/proxy/uec-dos-api-cs-proxy-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: uec-dos-api-cs-proxy-ingress

--- a/deployment/stacks/service/overlays/demo/template/uec-dos-api-cs-proxy-ingress-customisation.yaml
+++ b/deployment/stacks/service/overlays/demo/template/uec-dos-api-cs-proxy-ingress-customisation.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: uec-dos-api-cs-proxy-ingress

--- a/deployment/stacks/service/overlays/dev/template/uec-dos-api-cs-proxy-ingress-customisation.yaml
+++ b/deployment/stacks/service/overlays/dev/template/uec-dos-api-cs-proxy-ingress-customisation.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: uec-dos-api-cs-proxy-ingress


### PR DESCRIPTION
All other files look fine for the EKS upgrade, only the Ingress to change due to deprecation.